### PR TITLE
Use custom AMI if specified

### DIFF
--- a/certs/main.tf
+++ b/certs/main.tf
@@ -213,7 +213,7 @@ module "cluster" {
   region  = "${var.region}"
 
   # LC parameters
-  ami              = "${coalesce(lookup(var.ami_region_lookup, var.region), var.ami_custom)}"
+  ami              = "${coalesce(var.ami_custom, lookup(var.ami_region_lookup, var.region))}"
   instance_type    = "${var.instance_type}"
   instance_profile = "${aws_iam_instance_profile.profile.id}"
   user_data        = "${template_file.user_data.rendered}"

--- a/certs/variables.tf
+++ b/certs/variables.tf
@@ -41,7 +41,6 @@ variable "ami_region_lookup" {
   default = {
     us-east-1      = "ami-d66995bb"
     ap-northeast-1 = "ami-4803ec29"
-    custom         = ""
   }
 }
 


### PR DESCRIPTION
To enable use of a custom AMI in the current logic, the region variable needs to be set to "custom". Since the region variable is also used in other places, having it set to "custom" is unexpected and potentially problematic. To enable use of a custom AMI in a region where we have a default one available, reverse the order of the arguments to the coalesce method so that the custom AMI is used if specified.