### PR TITLE
Adding us-west-2 AMI ids

### DIFF
--- a/certs/variables.tf
+++ b/certs/variables.tf
@@ -41,6 +41,7 @@ variable "ami_region_lookup" {
   default = {
     us-east-1      = "ami-d66995bb"
     ap-northeast-1 = "ami-4803ec29"
+    us-west-2      = "ami-4308a323"
   }
 }
 

--- a/generate-certs/variables.tf
+++ b/generate-certs/variables.tf
@@ -25,6 +25,7 @@ variable "ami_region_lookup" {
   default = {
     us-east-1      = "ami-6934c804"
     ap-northeast-1 = "ami-b036d9d1"
+    us-west-2      = "ami-530fa433"
     custom         = ""
   }
 }


### PR DESCRIPTION
- Copied ami-d66995bb[openvpn-pam-0.0.5] us-east-1 to us-west-2 ami-4308a323
- Copied ami-ami-6934c804[openvpn-generate-certs-0.0.1] us-east-1 to us-west-2 ami-530fa433
- Made ami's public 
- Added these to the ami map for us-west-2 