### PR TITLE
Split list for proper handling in asg module

### DIFF
--- a/certs/main.tf
+++ b/certs/main.tf
@@ -205,7 +205,7 @@ module "cluster" {
 
   # VPC parameters
   vpc_id  = "${var.vpc_id}"
-  subnets = ["${var.subnets}"]
+  subnets = ["${split(",",var.subnets)}"]
 
   # LC parameters
   ami                           = "${coalesce(var.ami_custom, lookup(var.ami_region_lookup, var.region))}"


### PR DESCRIPTION
- Subnets should be split at csv delimeter for properly handling in asg module.
- Also see 