### PR TITLE
Rollup of changes from WhistleLabs fork

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,15 +29,6 @@ common_steps: &common_steps
      name: "Test: verify plan"
      command: |
        bundle install
-
-       if [ "$TF_LEGACY" != "true" ]; then
-         for example in $(ls -d examples/*/); do
-           pushd $example
-           terraform init
-           popd
-         done
-       fi
-
        bundle exec rake
 
  - save_cache:
@@ -50,20 +41,6 @@ common_steps: &common_steps
        - /usr/local/bundle
 
 jobs:
-  0.8.8:
-    docker:
-      - image: circleci/ruby
-    environment:
-      - TF_VERSION: 0.8.8
-      - TF_LEGACY: true
-    steps: *common_steps
-  0.9.11:
-    docker:
-      - image: circleci/ruby
-    environment:
-      - TF_VERSION: 0.9.11
-      - TF_LEGACY: true
-    steps: *common_steps
   0.10.7:
     docker:
       - image: circleci/ruby
@@ -82,8 +59,6 @@ workflows:
 
   some_flow:
     jobs:
-      - 0.8.8
-      - 0.9.11
       - 0.10.7
       - 0.11.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,31 @@
 ## Unreleased
 
-## ???
+## 1.0.0
 
+#### IMPROVEMENTS:
+
+Rollup fixes from whistle/terraform-aws-openvpn 0.0.9 - 0.2.5
+- Update server.conf with VPC DNS IP address
 - Feature: Automatically push instance's subnet route into `server.conf`
 - export `zone_id`, `dns_name` from aws_elb
 - Fix the 4 subnet fixed mapping
 - Fill in some examples
+- Add additional configuration options to Openvpn (#15)
+  * Add eip and extra route capability
+  * Update formatting
+  * Fix the tag filter
+- OpenVPN CertGen RoleID Output (DEVOPS-1692)
+- OpenVPN RoleID Output (DEVOPS-1613)
+- Configure DNS entry in server.conf
+- Pin template provider version
+- Adding crl-verify to server.conf
+- Change permissions temporarily in user_data to avoid AMI change
+
+
+## 0.0.11
+
+#### IMPROVEMENTS:
+- Terraform 0.8.x compatibility updates.
 
 ## 0.0.10
 

--- a/certs/outputs.tf
+++ b/certs/outputs.tf
@@ -15,3 +15,7 @@ output "vpn_elb_dns_name" {
 output "vpn_elb_zone_id" {
   value = "${aws_elb.elb.zone_id}"
 }
+
+output "role_id_openvpn" {
+  value = "${aws_iam_role.role.unique_id}"
+}

--- a/certs/templates/user_data.tpl
+++ b/certs/templates/user_data.tpl
@@ -1,13 +1,20 @@
 #cloud-config
 runcmd:
+  - export INSTANCE_ID=`curl http://169.254.169.254/latest/meta-data/instance-id`
   - echo "OPENVPN_CERT_SOURCE=s3://${replace(s3_bucket,"/(/)+$/","")}/${replace(s3_bucket_prefix,"/^(/)+|(/)+$/","")}" > /etc/openvpn/get-openvpn-certs.env
+  - echo "push \"dhcp-option DNS ${vpc_dns_ip}\"" >> /etc/openvpn/server.conf
+  - echo 'crl-verify /etc/openvpn/keys/crl.pem' >> /etc/openvpn/server.conf
   - echo "push \"route $(ip route get 8.8.8.8| grep src| sed 's/.*src \(.*\)$/\1/g') 255.255.255.255 net_gateway\"" >> /etc/openvpn/server.conf
   - echo "push \"route ${cidrhost(element(split(",",route_cidrs),1), 0)}  ${cidrnetmask(element(split(",",route_cidrs),1))}\"" >> /etc/openvpn/server.conf
   - echo "push \"route ${cidrhost(element(split(",",route_cidrs),2), 0)}  ${cidrnetmask(element(split(",",route_cidrs),2))}\"" >> /etc/openvpn/server.conf
   - echo "push \"route ${cidrhost(element(split(",",route_cidrs),3), 0)}  ${cidrnetmask(element(split(",",route_cidrs),3))}\"" >> /etc/openvpn/server.conf
   - echo "push \"route ${cidrhost(element(split(",",route_cidrs),4), 0)}  ${cidrnetmask(element(split(",",route_cidrs),4))}\"" >> /etc/openvpn/server.conf
+  - for route in `echo ${additional_routes} | tr ',' ' '`; do echo "push \"route $${route}  255.255.255.255\"" >> /etc/openvpn/server.conf;done
+  - sed -i 's/\(ExecStartPost=.*chmod.*$\)/ExecStartPost=\/bin\/chown -R nobody:nogroup \/etc\/openvpn\n\1\n/g' /etc/systemd/system/get-openvpn-certs.service
+  - systemctl daemon-reload
   - systemctl start get-openvpn-certs
   - systemctl restart openvpn@server
   - systemctl restart iptables
+  - if [ ${assign_eip} = 'true' ]; then for eip in `aws ec2 describe-tags --region=${region} --filters  "Name=resource-type,Values=elastic-ip" "Name=value,Values=${stack_item_label}" | jq -r '.Tags[].ResourceId'`; do if [ `aws ec2 describe-addresses --allocation-id $${eip} --region=${region} | jq -r '.Addresses[].InstanceId'` = 'null' ]; then echo "$${eip} is available, assigning it to current instance";aws ec2 associate-address --instance-id "$${INSTANCE_ID}" --allocation-id $${eip} --region=${region};else echo "$${eip} is taken";fi; done;fi
 
 output : { all : '| tee -a /var/log/cloud-init-output.log' }

--- a/certs/templates/user_data.tpl
+++ b/certs/templates/user_data.tpl
@@ -2,7 +2,7 @@
 runcmd:
   - export INSTANCE_ID=`curl http://169.254.169.254/latest/meta-data/instance-id`
   - echo "OPENVPN_CERT_SOURCE=s3://${replace(s3_bucket,"/(/)+$/","")}/${replace(s3_bucket_prefix,"/^(/)+|(/)+$/","")}" > /etc/openvpn/get-openvpn-certs.env
-  - echo "push \"dhcp-option DNS ${vpc_dns_ip}\"" >> /etc/openvpn/server.conf
+  - if [ -n "${vpc_dns_ip}" ]; then echo "push \"dhcp-option DNS ${vpc_dns_ip}\"" >> /etc/openvpn/server.conf;fi
   - echo 'crl-verify /etc/openvpn/keys/crl.pem' >> /etc/openvpn/server.conf
   - echo "push \"route $(ip route get 8.8.8.8| grep src| sed 's/.*src \(.*\)$/\1/g') 255.255.255.255 net_gateway\"" >> /etc/openvpn/server.conf
   - echo "push \"route ${cidrhost(element(split(",",route_cidrs),1), 0)}  ${cidrnetmask(element(split(",",route_cidrs),1))}\"" >> /etc/openvpn/server.conf

--- a/certs/variables.tf
+++ b/certs/variables.tf
@@ -45,8 +45,10 @@ variable "ami_region_lookup" {
   type = "map"
 
   default = {
-    us-east-1 = "ami-44e8913e"
-    us-east-2 = "ami-d1c9e1b4"
+    us-east-1      = "ami-6934c804"
+    ap-northeast-1 = "ami-b036d9d1"
+    us-west-2      = "ami-530fa433"
+    custom         = ""
   }
 }
 

--- a/certs/variables.tf
+++ b/certs/variables.tf
@@ -107,6 +107,7 @@ variable "ssh_whitelist" {
 variable "vpc_dns_ip" {
   type        = "string"
   description = "DNS IP address for the VPC."
+  default     = ""
 }
 
 variable "vpn_whitelist" {

--- a/certs/variables.tf
+++ b/certs/variables.tf
@@ -28,6 +28,12 @@ variable "subnets" {
 }
 
 ## OpenVPN parameters
+variable "additional_routes" {
+  type        = "string"
+  description = "Additional routes to add to Openvpn Config"
+  default     = ""
+}
+
 variable "ami_custom" {
   type        = "string"
   description = "Custom AMI to utilize"
@@ -39,15 +45,26 @@ variable "ami_region_lookup" {
   type = "map"
 
   default = {
-    us-east-1      = "ami-d66995bb"
-    ap-northeast-1 = "ami-4803ec29"
-    us-west-2      = "ami-4308a323"
+    us-east-1 = "ami-44e8913e"
+    us-east-2 = "ami-d1c9e1b4"
   }
 }
 
 variable "instance_based_naming_enabled" {
   type        = "string"
   description = "Flag to enable instance-id based name tagging."
+  default     = ""
+}
+
+variable "assign_eip" {
+  type        = "string"
+  description = "Boolean to determine if Elastic IP should be assigned to host"
+  default     = "false"
+}
+
+variable "eip_tag" {
+  type        = "string"
+  description = "Tag used to lookup Elastic IP to assign"
   default     = ""
 }
 
@@ -81,14 +98,19 @@ variable "s3_bucket_prefix" {
   default     = ""
 }
 
-variable "vpn_whitelist" {
-  type        = "string"
-  description = "Limit VPN access to the designated list of CIDRs"
-  default     = "0.0.0.0/0"
-}
-
 variable "ssh_whitelist" {
   type        = "string"
   description = "Limit SSH access to the designated list of CIDRs"
+  default     = "0.0.0.0/0"
+}
+
+variable "vpc_dns_ip" {
+  type        = "string"
+  description = "DNS IP address for the VPC."
+}
+
+variable "vpn_whitelist" {
+  type        = "string"
+  description = "Limit VPN access to the designated list of CIDRs"
   default     = "0.0.0.0/0"
 }

--- a/examples/server/main.tf
+++ b/examples/server/main.tf
@@ -24,4 +24,8 @@ module "openvpn_server" {
   route_cidrs      = "${var.route_cidrs}"
   s3_bucket        = "${var.s3_bucket}"
   s3_bucket_prefix = "${var.s3_bucket_prefix}"
+
+  assign_eip = "true"
+  eip_tag    = "openvpn-instance"
+  vpc_dns_ip = "1.1.1.1"
 }

--- a/generate-certs/main.tf
+++ b/generate-certs/main.tf
@@ -1,5 +1,9 @@
 # OpenVPN Certificate Generator
 
+provider "template" {
+  version = "~> 0.1"
+}
+
 ## Creates IAM role & policies
 resource "aws_iam_role" "role" {
   name = "${var.stack_item_label}-${var.region}"
@@ -66,6 +70,7 @@ resource "aws_iam_role_policy" "tags" {
       "Effect": "Allow",
       "Action": [
           "ec2:CreateTags",
+          "ec2:DescribeTags",
           "ec2:AssociateAddress",
           "ec2:DescribeAddresses",
           "ec2:DescribeInstances"
@@ -79,8 +84,8 @@ EOF
 
 ## Creates IAM instance profile
 resource "aws_iam_instance_profile" "profile" {
-  name  = "${var.stack_item_label}-${var.region}"
-  roles = ["${aws_iam_role.role.name}"]
+  name = "${var.stack_item_label}-${var.region}"
+  role = "${aws_iam_role.role.name}"
 }
 
 ## Creates security group rules

--- a/generate-certs/outputs.tf
+++ b/generate-certs/outputs.tf
@@ -1,0 +1,5 @@
+# Outputs
+
+output "role_id_certgen" {
+  value = "${aws_iam_role.role.unique_id}"
+}

--- a/generate-certs/variables.tf
+++ b/generate-certs/variables.tf
@@ -23,9 +23,10 @@ variable "ami_region_lookup" {
   type = "map"
 
   default = {
-    us-east-1 = "ami-6d65687b"
-    us-east-2 = "ami-1dcbe878"
-    custom    = ""
+    us-east-1      = "ami-6934c804"
+    ap-northeast-1 = "ami-b036d9d1"
+    us-west-2      = "ami-530fa433"
+    custom         = ""
   }
 }
 

--- a/generate-certs/variables.tf
+++ b/generate-certs/variables.tf
@@ -23,10 +23,9 @@ variable "ami_region_lookup" {
   type = "map"
 
   default = {
-    us-east-1      = "ami-6934c804"
-    ap-northeast-1 = "ami-b036d9d1"
-    us-west-2      = "ami-530fa433"
-    custom         = ""
+    us-east-1 = "ami-6d65687b"
+    us-east-2 = "ami-1dcbe878"
+    custom    = ""
   }
 }
 


### PR DESCRIPTION
This is a rollup of changes from the WhistleLabs fork of this module, with a few minor changes afterwards for compatibility.

- Make vpc_dns_ip optional in `user_data` (769fb3a)

I'll tag this as a 1.0.0 version once 👍 , since there's terraform compatibility breakage here (requires TF > 0.10)