### PR TITLE
PoC module for docker-openvpn

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 *.tfstate*
 .terraform/
+docker-openvpn-server/terraform.tfvars*
+docker-openvpn-server/.env

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+* Bring in covalence to help with bootstrapping/testing. Consider some kitchen/localstack testing.
+* PoC docker-openvpn-server modules
+
 ## 1.0.0
 
 #### IMPROVEMENTS:

--- a/docker-openvpn-server/cluster/ami.tf
+++ b/docker-openvpn-server/cluster/ami.tf
@@ -1,0 +1,8 @@
+data "aws_ami" "cluster_ami" {
+  most_recent = true
+
+  filter {
+    name   = "name"
+    values = ["amzn-ami-*-amazon-ecs-optimized"]
+  }
+}

--- a/docker-openvpn-server/cluster/eip.tf
+++ b/docker-openvpn-server/cluster/eip.tf
@@ -1,0 +1,10 @@
+resource "aws_eip" "openvpn_eip" {
+  count = "${var.assign_eip == "true" ? 1 : 0}"
+  vpc   = true
+
+  tags {
+    application = "${var.stack_item_fullname}"
+    managed_by  = "terraform"
+    Name        = "${var.stack_item_label}"
+  }
+}

--- a/docker-openvpn-server/cluster/iam.tf
+++ b/docker-openvpn-server/cluster/iam.tf
@@ -1,0 +1,102 @@
+# inputs
+locals {
+  in_iam_stack_item_label = "${var.stack_item_label}"
+  in_iam_region           = "${var.region}"
+  in_iam_s3_bucket        = "${var.s3_bucket}"
+  in_iam_s3_bucket_prefix = "${var.s3_bucket_prefix}"
+}
+
+# local vars for the file
+locals {
+  local_iam_name           = "${local.in_iam_stack_item_label}-${local.in_iam_region}"
+  local_iam_s3_full_path   = "${replace(local.in_iam_s3_bucket,"/(/)+$/","")}/${replace(local.in_iam_s3_bucket_prefix,"/^(/)+|(/)+$/","")}"
+  local_iam_s3_bucket_path = "${replace(local.in_iam_s3_bucket,"/(/)+$/","")}"
+}
+
+## Creates IAM role & policies
+resource "aws_iam_role" "role" {
+  name = "${local.local_iam_name}"
+  path = "/"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "sts:AssumeRole",
+      "Principal": {
+         "Service": "ec2.amazonaws.com"
+      }
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "s3_certs_ro" {
+  name = "s3_certs_ro"
+  role = "${aws_iam_role.role.id}"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:Get*"
+      ],
+      "Resource": [
+        "arn:aws:s3:::${local.local_iam_s3_full_path}",
+        "arn:aws:s3:::${local.local_iam_s3_full_path}/*"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:List*"
+      ],
+      "Resource": [
+        "arn:aws:s3:::${local.local_iam_s3_bucket_path}"
+      ]
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "tags" {
+  name = "tags"
+  role = "${aws_iam_role.role.id}"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+          "ec2:CreateTags",
+          "ec2:DescribeTags",
+          "ec2:AssociateAddress",
+          "ec2:DescribeAddresses",
+          "ec2:DescribeInstances"
+      ],
+      "Resource": "*"
+    }
+  ]
+}
+EOF
+}
+
+## Creates IAM instance profile
+resource "aws_iam_instance_profile" "profile" {
+  name = "${local.local_iam_name}"
+  role = "${aws_iam_role.role.name}"
+}
+
+## outputs
+locals {
+  out_iam_instance_profile_id = "${aws_iam_instance_profile.profile.id}"
+}

--- a/docker-openvpn-server/cluster/main.tf
+++ b/docker-openvpn-server/cluster/main.tf
@@ -1,0 +1,58 @@
+provider "template" {
+  version = "~> 1.0.0"
+}
+
+locals {
+  user_data_vars = {
+    additional_routes    = "${var.additional_routes}"
+    assign_eip           = "${var.assign_eip}"
+    hostname             = "${var.stack_item_label}"
+    s3_bucket            = "${var.s3_bucket}"
+    s3_bucket_prefix     = "${coalesce(var.s3_bucket_prefix_for_service, var.s3_bucket_prefix)}"
+    stack_item_label     = "${var.stack_item_label}"
+    region               = "${var.region}"
+    route_cidrs          = "${var.route_cidrs}"
+    vpc_dns_ip           = "${var.vpc_dns_ip}"
+    openvpn_docker_image = "${var.openvpn_docker_image}"
+    openvpn_docker_tag   = "${var.openvpn_docker_tag}"
+  }
+}
+
+## Creates instance user data
+data "template_file" "user_data" {
+  template = "${file("${path.module}/templates/user_data.tpl")}"
+  vars     = "${local.user_data_vars}"
+}
+
+## Creates auto scaling cluster
+module "cluster" {
+  source = "github.com/unifio/terraform-aws-asg?ref=v0.3.2//group"
+
+  # Resource tags
+  stack_item_label    = "${var.stack_item_label}"
+  stack_item_fullname = "${var.stack_item_fullname}"
+
+  # VPC parameters
+  vpc_id  = "${var.vpc_id}"
+  subnets = ["${split(",",var.subnets)}"]
+
+  # LC parameters
+  ami                           = "${coalesce(var.ami_custom, data.aws_ami.cluster_ami.id)}"
+  ebs_optimized                 = "false"
+  enable_monitoring             = "true"
+  instance_based_naming_enabled = "${var.instance_based_naming_enabled}"
+  instance_profile              = "${aws_iam_instance_profile.profile.id}"
+  instance_type                 = "${var.instance_type}"
+  key_name                      = "${var.key_name}"
+  user_data                     = "${coalesce(var.ami_custom_user_data, data.template_file.user_data.rendered)}"
+  associate_public_ip_address   = "${var.associate_public_ip_address}"
+
+  # ASG parameters
+  enabled_metrics   = "${var.enabled_metrics}"
+  hc_check_type     = "${var.enable_lb == "true" ? "ELB" : "EC2"}"
+  instance_tags     = "${var.instance_tags}"
+  max_size          = 2
+  min_size          = 1
+  hc_grace_period   = 300
+  target_group_arns = "${var.lb_target_group_arns}"
+}

--- a/docker-openvpn-server/cluster/sg.tf
+++ b/docker-openvpn-server/cluster/sg.tf
@@ -1,0 +1,43 @@
+# inputs
+locals {
+  in_sg_id            = "${module.cluster.sg_id}"
+  in_sg_vpn_whitelist = "${var.vpn_whitelist}"
+  in_sg_ssh_whitelist = "${var.ssh_whitelist}"
+}
+
+## Creates security group rules
+resource "aws_security_group_rule" "cluster_allow_all_out" {
+  type              = "egress"
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = "${local.in_sg_id}"
+}
+
+resource "aws_security_group_rule" "cluster_allow_openvpn_tcp_in" {
+  type              = "ingress"
+  from_port         = 1194
+  to_port           = 1194
+  protocol          = "tcp"
+  cidr_blocks       = ["${split(",",local.in_sg_vpn_whitelist)}"]
+  security_group_id = "${local.in_sg_id}"
+}
+
+resource "aws_security_group_rule" "cluster_allow_ssh_in" {
+  type              = "ingress"
+  from_port         = 22
+  to_port           = 22
+  protocol          = "tcp"
+  cidr_blocks       = ["${split(",",local.in_sg_ssh_whitelist)}"]
+  security_group_id = "${local.in_sg_id}"
+}
+
+resource "aws_security_group_rule" "cluster_allow_icmp_in" {
+  type              = "ingress"
+  from_port         = 0
+  to_port           = 0
+  protocol          = "icmp"
+  cidr_blocks       = ["${split(",",var.ssh_whitelist)}"]
+  security_group_id = "${local.in_sg_id}"
+}

--- a/docker-openvpn-server/cluster/templates/user_data.tpl
+++ b/docker-openvpn-server/cluster/templates/user_data.tpl
@@ -1,0 +1,31 @@
+#cloud-config
+runcmd:
+  - sleep 60
+  - yum update -y
+  - yum install jq -y
+  - curl -s -O https://bootstrap.pypa.io/get-pip.py && python get-pip.py
+  - /usr/local/bin/pip install awscli && ln -sf /usr/local/bin/aws /usr/bin/
+
+  - export INSTANCE_ID=`curl http://169.254.169.254/latest/meta-data/instance-id`
+  - docker pull ${openvpn_docker_image}:${openvpn_docker_tag}
+  - mkdir -p /opt/openvpn
+  - touch /opt/openvpn/.env && chmod 700 /opt/openvpn/.env
+  - touch /opt/openvpn/server-append.conf && chmod 700 /opt/openvpn/server-append.conf
+  - echo "OPENVPN_S3_PULL_CERTS=true" >> /opt/openvpn/.env
+  - echo "OPENVPN_S3_CERT_PATH=${replace(s3_bucket,"/(/)+$/","")}/${replace(s3_bucket_prefix,"/^(/)+|(/)+$/","")}" >> /opt/openvpn/.env
+  - if [ -n "${vpc_dns_ip}" ]; then echo "push \"dhcp-option DNS ${vpc_dns_ip}\"" >> /opt/openvpn/server-append.conf;fi
+  - echo "push \"route $(ip route get 8.8.8.8| grep src| sed 's/.*src \(.*\)$/\1/g') 255.255.255.255 net_gateway\"" >> /opt/openvpn/server-append.conf
+  - echo "push \"route ${cidrhost(element(split(",",route_cidrs),1), 0)}  ${cidrnetmask(element(split(",",route_cidrs),1))}\"" >> /opt/openvpn/server-append.conf
+  - echo "push \"route ${cidrhost(element(split(",",route_cidrs),2), 0)}  ${cidrnetmask(element(split(",",route_cidrs),2))}\"" >> /opt/openvpn/server-append.conf
+  - echo "push \"route ${cidrhost(element(split(",",route_cidrs),3), 0)}  ${cidrnetmask(element(split(",",route_cidrs),3))}\"" >> /opt/openvpn/server-append.conf
+  - echo "push \"route ${cidrhost(element(split(",",route_cidrs),4), 0)}  ${cidrnetmask(element(split(",",route_cidrs),4))}\"" >> /opt/openvpn/server-append.conf
+  - for route in `echo ${additional_routes} | tr ',' ' '`; do echo "push \"route $${route}  255.255.255.255\"" >> /opt/openvpn/server-append.conf;done
+
+  - echo "OPENVPN_COMPRESS_ALGORITHM=lzo" >> /opt/openvpn/.env
+  - echo "OPENVPN_KEY_DHSIZE=1024" >> /opt/openvpn/.env
+  - echo "OPENVPN_TLS_ENABLE=false" >> /opt/openvpn/.env
+
+  - docker run -d --name openvpn --env-file=/opt/openvpn/.env --cap-add=NET_ADMIN --device=/dev/net/tun -v /opt/openvpn/:/etc/openvpn/ -v /var/run/openvpn/:/var/run/openvpn -p 1194:1194/tcp ${openvpn_docker_image}:${openvpn_docker_tag} /start_server.sh
+  - if [ ${assign_eip} = 'true' ]; then for eip in `aws ec2 describe-tags --region=${region} --filters  "Name=resource-type,Values=elastic-ip" "Name=value,Values=${stack_item_label}" | jq -r '.Tags[].ResourceId'`; do if [ `aws ec2 describe-addresses --allocation-id $${eip} --region=${region} | jq -r '.Addresses[].InstanceId'` = 'null' ]; then echo "$${eip} is available, assigning it to current instance";aws ec2 associate-address --instance-id "$${INSTANCE_ID}" --allocation-id $${eip} --region=${region};else echo "$${eip} is taken";fi; done;fi
+
+output : { all : '| tee -a /var/log/cloud-init-output.log' }

--- a/docker-openvpn-server/cluster/variables.tf
+++ b/docker-openvpn-server/cluster/variables.tf
@@ -1,0 +1,167 @@
+# Input Variables
+
+## Resource tags
+variable "stack_item_label" {
+  type        = "string"
+  description = "Short form identifier for this stack. This value is used to create the 'Name' resource tag for resources created by this stack item, and also serves as a unique key for re-use."
+}
+
+variable "stack_item_fullname" {
+  type        = "string"
+  description = "Long form descriptive name for this stack item. This value is used to create the 'application' resource tag for resources created by this stack item."
+}
+
+variable "ami_custom" {
+  type        = "string"
+  description = "Custom AMI to utilize"
+  default     = ""
+}
+
+variable "ami_custom_user_data" {
+  type        = "string"
+  description = "Custom AMI instance user data to start the instance with"
+  default     = ""
+}
+
+variable "key_name" {
+  type        = "string"
+  description = "SSH key pair to associate with the launch configuration."
+}
+
+variable "vpc_id" {
+  type        = "string"
+  description = "ID of the target VPC."
+}
+
+variable "instance_type" {
+  type        = "string"
+  description = "EC2 instance type to associate with the launch configuration."
+  default     = "t2.small"
+}
+
+variable "subnets" {
+  type        = "string"
+  description = "List of VPC subnets to associate with the cluster."
+}
+
+variable "instance_based_naming_enabled" {
+  type        = "string"
+  description = "Flag to enable instance-id based name tagging."
+  default     = ""
+}
+
+variable "instance_tags" {
+  type = "map"
+
+  default = {
+    Name        = "openvpn_server"
+    application = "OpenVPN Server"
+    managed_by  = "terraform"
+  }
+}
+
+variable "enabled_metrics" {
+  type = "list"
+
+  default = [
+    "GroupDesiredCapacity",
+    "GroupInServiceInstances",
+    "GroupMaxSize",
+    "GroupMinSize",
+    "GroupPendingInstances",
+    "GroupStandbyInstances",
+    "GroupTerminatingInstances",
+    "GroupTotalInstances",
+  ]
+}
+
+variable "ssh_whitelist" {
+  type        = "string"
+  description = "Limit SSH access to the designated list of CIDRs"
+  default     = "0.0.0.0/0"
+}
+
+variable "enable_lb" {
+  type        = "string"
+  description = "String boolean of whether or not to expect a load balancer to be attached to this ASG cluster"
+  default     = "false"
+}
+
+variable "vpn_whitelist" {
+  type        = "string"
+  description = "Limit VPN access to the designated list of CIDRs"
+  default     = "0.0.0.0/0"
+}
+
+### Do not include the trailing slash
+variable "s3_bucket_prefix" {
+  type        = "string"
+  description = "The S3 bucket prefix. Certificates and configuration will be sourced from the root if not configured."
+  default     = ""
+}
+
+variable "s3_bucket" {
+  type        = "string"
+  description = "The S3 bucket where certificate and configuration are stored."
+}
+
+variable "region" {
+  type        = "string"
+  description = "AWS region to be utilized."
+}
+
+variable "assign_eip" {
+  type        = "string"
+  description = "Boolean to determine if Elastic IP should be assigned to host"
+  default     = "false"
+}
+
+### TODO: expects 4 subnets to map as internal network routes.
+### Fix the magic # problem
+variable "route_cidrs" {
+  type        = "string"
+  description = "Routes for the VPN server to expose"
+  default     = ""
+}
+
+variable "s3_bucket_prefix_for_service" {
+  type        = "string"
+  description = "Actual s3 path (without the bucket prefix) that the openvpn service will use, if different from IAM path permissions"
+  default     = ""
+}
+
+variable "additional_routes" {
+  type        = "string"
+  description = "Additional routes to add to Openvpn Config"
+  default     = ""
+}
+
+variable "vpc_dns_ip" {
+  type        = "string"
+  description = "Optional: DNS IP address for the VPC."
+  default     = ""
+}
+
+variable "openvpn_docker_image" {
+  type        = "string"
+  description = "Docker image for the openvpn container instance"
+  default     = "unifio/openvpn"
+}
+
+variable "openvpn_docker_tag" {
+  type        = "string"
+  description = "Docker image for the openvpn container instance"
+  default     = "latest"
+}
+
+variable "associate_public_ip_address" {
+  type        = "string"
+  description = "Flag for associating public IP addresses with instances managed by the auto scaling group."
+  default     = ""
+}
+
+variable "lb_target_group_arns" {
+  type        = "list"
+  description = "target group arns to associate with the NLB, if enable_lb == true"
+  default     = []
+}

--- a/docker-openvpn-server/endpoint/main.tf
+++ b/docker-openvpn-server/endpoint/main.tf
@@ -1,0 +1,64 @@
+resource "aws_lb" "openvpn" {
+  name = "${var.stack_item_label}-nlb"
+
+  internal           = false
+  load_balancer_type = "network"
+
+  #TODO:
+  security_groups = []
+  subnets         = ["${split(",", coalesce(var.lb_subnets, var.subnets))}"]
+
+  access_logs {
+    bucket  = "${var.lb_logs_bucket}"
+    prefix  = "${var.lb_logs_bucket_prefix}"
+    enabled = "${var.lb_logs_enabled}"
+  }
+
+  tags {
+    Name        = "${var.stack_item_label}"
+    application = "${var.stack_item_fullname}"
+    managed_by  = "terraform"
+  }
+}
+
+resource "aws_lb_target_group" "openvpn" {
+  name     = "${var.stack_item_label}-nlb"
+  port     = 1194
+  protocol = "TCP"
+
+  vpc_id = "${var.vpc_id}"
+
+  #deregistration_delay
+  health_check {
+    healthy_threshold   = 4
+    unhealthy_threshold = 4
+
+    # default is 10, that cannot be changed for an NLB
+    #timeout            = 10
+    port = 1194
+
+    protocol = "TCP"
+    interval = 30
+  }
+
+  tags {
+    Name        = "${var.stack_item_label}"
+    application = "${var.stack_item_fullname}"
+    managed_by  = "terraform"
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_lb_listener" "openvpn" {
+  load_balancer_arn = "${aws_lb.openvpn.arn}"
+  port              = 1194
+  protocol          = "TCP"
+
+  default_action {
+    target_group_arn = "${aws_lb_target_group.openvpn.id}"
+    type             = "forward"
+  }
+}

--- a/docker-openvpn-server/endpoint/outputs.tf
+++ b/docker-openvpn-server/endpoint/outputs.tf
@@ -1,0 +1,11 @@
+output "lb_dns_name" {
+  value = "${aws_lb.openvpn.dns_name}"
+}
+
+output "lb_dns_zone_id" {
+  value = "${aws_lb.openvpn.zone_id}"
+}
+
+output "lb_target_group_arns" {
+  value = "${aws_lb_target_group.openvpn.arn}"
+}

--- a/docker-openvpn-server/endpoint/variables.tf
+++ b/docker-openvpn-server/endpoint/variables.tf
@@ -1,0 +1,46 @@
+# Input Variables
+
+## Resource tags
+variable "stack_item_label" {
+  type        = "string"
+  description = "Short form identifier for this stack. This value is used to create the 'Name' resource tag for resources created by this stack item, and also serves as a unique key for re-use."
+}
+
+variable "stack_item_fullname" {
+  type        = "string"
+  description = "Long form descriptive name for this stack item. This value is used to create the 'application' resource tag for resources created by this stack item."
+}
+
+variable "subnets" {
+  type        = "string"
+  description = "List of VPC subnets to associate with the cluster."
+}
+
+variable "lb_subnets" {
+  type        = "string"
+  description = "List of VPC subnets to associate with the lb. Defaults to the same one as the cluster if not set"
+  default     = ""
+}
+
+variable "lb_logs_enabled" {
+  type        = "string"
+  description = "String boolean of whether or not to enable access logs for the lb"
+  default     = "false"
+}
+
+variable "lb_logs_bucket" {
+  type        = "string"
+  description = "S3 bucket for the lb access logs"
+  default     = ""
+}
+
+variable "lb_logs_bucket_prefix" {
+  type        = "string"
+  description = "S3 bucket prefix for the lb access logs"
+  default     = ""
+}
+
+variable "vpc_id" {
+  type        = "string"
+  description = "ID of the target VPC."
+}

--- a/docker-openvpn-server/main.tf
+++ b/docker-openvpn-server/main.tf
@@ -1,0 +1,48 @@
+provider "aws" {
+  region = "${var.region}"
+}
+
+module "cluster" {
+  source = "cluster"
+
+  stack_item_label              = "${var.stack_item_label}"
+  stack_item_fullname           = "${var.stack_item_fullname}"
+  ami_custom                    = "${var.ami_custom}"
+  ami_custom_user_data          = "${var.ami_custom_user_data}"
+  key_name                      = "${var.key_name}"
+  vpc_id                        = "${var.vpc_id}"
+  instance_type                 = "${var.instance_type}"
+  subnets                       = "${var.subnets}"
+  instance_based_naming_enabled = "${var.instance_based_naming_enabled}"
+  instance_tags                 = "${var.instance_tags}"
+  enabled_metrics               = "${var.enabled_metrics}"
+  ssh_whitelist                 = "${var.ssh_whitelist}"
+  enable_lb                     = "${var.enable_lb}"
+  vpn_whitelist                 = "${var.vpn_whitelist}"
+  region                        = "${var.region}"
+  s3_bucket                     = "${var.s3_bucket}"
+  s3_bucket_prefix              = "${var.s3_bucket_prefix}"
+  s3_bucket_prefix_for_service  = "${var.s3_bucket_prefix_for_service}"
+  additional_routes             = "${var.additional_routes}"
+  assign_eip                    = "${var.assign_eip}"
+  route_cidrs                   = "${var.route_cidrs}"
+  additional_routes             = "${var.additional_routes}"
+  vpc_dns_ip                    = "${var.vpc_dns_ip}"
+  openvpn_docker_image          = "${var.openvpn_docker_image}"
+  openvpn_docker_tag            = "${var.openvpn_docker_tag}"
+  associate_public_ip_address   = "${var.associate_public_ip_address}"
+  lb_target_group_arns          = ["${module.endpoint.lb_target_group_arns}"]
+}
+
+module "endpoint" {
+  source = "endpoint"
+
+  stack_item_label      = "${var.stack_item_label}"
+  stack_item_fullname   = "${var.stack_item_fullname}"
+  subnets               = "${var.subnets}"
+  lb_subnets            = "${var.lb_subnets}"
+  lb_logs_enabled       = "${var.lb_logs_enabled}"
+  lb_logs_bucket        = "${var.lb_logs_bucket}"
+  lb_logs_bucket_prefix = "${var.lb_logs_bucket_prefix}"
+  vpc_id                = "${var.vpc_id}"
+}

--- a/docker-openvpn-server/outputs.tf
+++ b/docker-openvpn-server/outputs.tf
@@ -1,0 +1,17 @@
+# Outputs
+/*output "vpn_server_sg_id" {*/
+/*value = "${module.cluster.sg_id}"*/
+/*}*/
+/*output "vpn_whitelist" {*/
+/*value = "${var.vpn_whitelist}"*/
+/*}*/
+/*output "vpn_elb_dns_name" {*/
+/*value = "${aws_elb.elb.dns_name}"*/
+/*}*/
+/*output "vpn_elb_zone_id" {*/
+/*value = "${aws_elb.elb.zone_id}"*/
+/*}*/
+/*output "role_id_openvpn" {*/
+/*value = "${aws_iam_role.role.unique_id}"*/
+/*}*/
+

--- a/docker-openvpn-server/variables.tf
+++ b/docker-openvpn-server/variables.tf
@@ -1,0 +1,193 @@
+# Input Variables
+
+## Resource tags
+variable "stack_item_label" {
+  type        = "string"
+  description = "Short form identifier for this stack. This value is used to create the 'Name' resource tag for resources created by this stack item, and also serves as a unique key for re-use."
+}
+
+variable "stack_item_fullname" {
+  type        = "string"
+  description = "Long form descriptive name for this stack item. This value is used to create the 'application' resource tag for resources created by this stack item."
+}
+
+## VPC parameters
+variable "vpc_id" {
+  type        = "string"
+  description = "ID of the target VPC."
+}
+
+variable "region" {
+  type        = "string"
+  description = "AWS region to be utilized."
+}
+
+variable "subnets" {
+  type        = "string"
+  description = "List of VPC subnets to associate with the cluster."
+}
+
+## OpenVPN parameters
+variable "additional_routes" {
+  type        = "string"
+  description = "Additional routes to add to Openvpn Config"
+  default     = ""
+}
+
+variable "ami_custom" {
+  type        = "string"
+  description = "Custom AMI to utilize"
+  default     = ""
+}
+
+variable "ami_custom_user_data" {
+  type        = "string"
+  description = "Custom AMI user data to use"
+  default     = ""
+}
+
+variable "instance_based_naming_enabled" {
+  type        = "string"
+  description = "Flag to enable instance-id based name tagging."
+  default     = ""
+}
+
+variable "assign_eip" {
+  type        = "string"
+  description = "Boolean to determine if Elastic IP should be assigned to host"
+  default     = "false"
+}
+
+variable "eip_tag" {
+  type        = "string"
+  description = "Tag used to lookup Elastic IP to assign"
+  default     = ""
+}
+
+variable "instance_type" {
+  type        = "string"
+  description = "EC2 instance type to associate with the launch configuration."
+  default     = "t2.small"
+}
+
+variable "key_name" {
+  type        = "string"
+  description = "SSH key pair to associate with the launch configuration."
+}
+
+### TODO: expects 4 subnets to map as internal network routes.
+### Fix the magic # problem
+variable "route_cidrs" {
+  type        = "string"
+  description = "Routes for the VPN server to expose, comma delimited"
+  default     = ""
+}
+
+variable "s3_bucket" {
+  type        = "string"
+  description = "The S3 bucket where certificate and configuration are stored."
+}
+
+### Do not include the trailing slash
+variable "s3_bucket_prefix" {
+  type        = "string"
+  description = "The S3 bucket prefix. Certificates and configuration will be sourced from the root if not configured."
+  default     = ""
+}
+
+variable "ssh_whitelist" {
+  type        = "string"
+  description = "Limit SSH access to the designated list of CIDRs"
+  default     = "0.0.0.0/0"
+}
+
+variable "vpc_dns_ip" {
+  type        = "string"
+  description = "Optional: DNS IP address for the VPC."
+  default     = ""
+}
+
+variable "vpn_whitelist" {
+  type        = "string"
+  description = "Limit VPN access to the designated list of CIDRs"
+  default     = "0.0.0.0/0"
+}
+
+# New variables
+variable "enable_lb" {
+  type        = "string"
+  description = "String boolean of whether or not to expect a load balancer to be attached to this ASG cluster"
+  default     = "false"
+}
+
+variable "enabled_metrics" {
+  type = "list"
+
+  default = [
+    "GroupDesiredCapacity",
+    "GroupInServiceInstances",
+    "GroupMaxSize",
+    "GroupMinSize",
+    "GroupPendingInstances",
+    "GroupStandbyInstances",
+    "GroupTerminatingInstances",
+    "GroupTotalInstances",
+  ]
+}
+
+variable "instance_tags" {
+  type = "map"
+
+  default = {
+    Name       = "openvpn_server"
+    managed_by = "terraform"
+  }
+}
+
+variable "s3_bucket_prefix_for_service" {
+  type        = "string"
+  description = "Actual s3 path (without the bucket prefix) that the openvpn service will use, if different from IAM path permissions"
+  default     = ""
+}
+
+variable "openvpn_docker_image" {
+  type        = "string"
+  description = "Docker image for the openvpn container instance"
+  default     = "unifio/openvpn"
+}
+
+variable "openvpn_docker_tag" {
+  type        = "string"
+  description = "Docker image for the openvpn container instance"
+  default     = "latest"
+}
+
+variable "associate_public_ip_address" {
+  type        = "string"
+  description = "Flag for associating public IP addresses with instances managed by the auto scaling group."
+  default     = ""
+}
+
+variable "lb_subnets" {
+  type        = "string"
+  description = "List of VPC subnets to associate with the lb. Defaults to the same one as the cluster if not set"
+  default     = ""
+}
+
+variable "lb_logs_enabled" {
+  type        = "string"
+  description = "String boolean of whether or not to enable access logs for the lb"
+  default     = "false"
+}
+
+variable "lb_logs_bucket" {
+  type        = "string"
+  description = "S3 bucket for the lb access logs"
+  default     = ""
+}
+
+variable "lb_logs_bucket_prefix" {
+  type        = "string"
+  description = "S3 bucket prefix for the lb access logs"
+  default     = ""
+}


### PR DESCRIPTION
Dockerized TF module that relies on unifio-openvpn underneath, less
dependent on host OS. Switches to using an NLB although optional with
the use of the the `enable_lb` flag on the cluster module