### PR TITLE
v1.0.1 fixes

### DIFF
--- a/docker-openvpn-server/cluster/main.tf
+++ b/docker-openvpn-server/cluster/main.tf
@@ -1,5 +1,5 @@
 provider "template" {
-  version = "~> 1.0.0"
+  version = ">= 0.1.0"
 }
 
 locals {
@@ -53,6 +53,6 @@ module "cluster" {
   instance_tags     = "${var.instance_tags}"
   max_size          = 2
   min_size          = 1
-  hc_grace_period   = 300
+  hc_grace_period   = "${var.hc_grace_period}"
   target_group_arns = "${var.lb_target_group_arns}"
 }

--- a/docker-openvpn-server/cluster/variables.tf
+++ b/docker-openvpn-server/cluster/variables.tf
@@ -121,7 +121,7 @@ variable "assign_eip" {
 variable "route_cidrs" {
   type        = "string"
   description = "Routes for the VPN server to expose"
-  default     = ""
+  default     = "10.8.0.0/24"
 }
 
 variable "s3_bucket_prefix_for_service" {
@@ -164,4 +164,10 @@ variable "lb_target_group_arns" {
   type        = "list"
   description = "target group arns to associate with the NLB, if enable_lb == true"
   default     = []
+}
+
+variable "hc_grace_period" {
+  type        = "string"
+  description = "Health check grace period for ASG"
+  default     = "300"
 }


### PR DESCRIPTION
- Better defaults for cidr_routes to not break terraform interpolation.
- More tolerant version requirements for terraform template
- Configurable `hc_grace_period` for the ASG cluster.