### PR TITLE
Cluster module version bump

### DIFF
--- a/certs/main.tf
+++ b/certs/main.tf
@@ -218,7 +218,7 @@ data "template_file" "user_data" {
 
 ## Creates auto scaling cluster
 module "cluster" {
-  source = "github.com/unifio/terraform-aws-asg?ref=v0.3.1//group"
+  source = "github.com/unifio/terraform-aws-asg?ref=v0.3.5//group"
 
   # Resource tags
   stack_item_label    = "${var.stack_item_label}"

--- a/docker-openvpn-server/cluster/main.tf
+++ b/docker-openvpn-server/cluster/main.tf
@@ -26,7 +26,7 @@ data "template_file" "user_data" {
 
 ## Creates auto scaling cluster
 module "cluster" {
-  source = "github.com/unifio/terraform-aws-asg?ref=v0.3.2//group"
+  source = "github.com/unifio/terraform-aws-asg?ref=v0.3.5//group"
 
   # Resource tags
   stack_item_label    = "${var.stack_item_label}"


### PR DESCRIPTION
* Bump referenced cluster module in `/certs`: 0.3.1 -> 0.3.5
* Bump referenced cluster module in `/docker-openvpn-server`: 0.3.2 -> 0.3.5