### PR TITLE
Adding support for additional asg tags

### DIFF
--- a/certs/main.tf
+++ b/certs/main.tf
@@ -218,7 +218,7 @@ data "template_file" "user_data" {
 
 ## Creates auto scaling cluster
 module "cluster" {
-  source = "github.com/unifio/terraform-aws-asg?ref=v0.3.5//group"
+  source = "github.com/unifio/terraform-aws-asg?ref=v0.3.6//group"
 
   # Resource tags
   stack_item_label    = "${var.stack_item_label}"
@@ -239,9 +239,10 @@ module "cluster" {
   user_data                     = "${data.template_file.user_data.rendered}"
 
   # ASG parameters
-  max_size         = 2
-  min_size         = 1
-  hc_grace_period  = 300
-  min_elb_capacity = 1
-  load_balancers   = ["${split(",",aws_elb.elb.id)}"]
+  additional_asg_tags = "${var.additional_asg_tags}"
+  max_size            = 2
+  min_size            = 1
+  hc_grace_period     = 300
+  min_elb_capacity    = 1
+  load_balancers      = ["${split(",",aws_elb.elb.id)}"]
 }

--- a/certs/variables.tf
+++ b/certs/variables.tf
@@ -64,6 +64,12 @@ variable "assign_eip" {
   default     = "false"
 }
 
+variable "additional_asg_tags" {
+  type        = "list"
+  description = "Additional tags to apply at the ASG level, if any"
+  default     = []
+}
+
 variable "eip_tag" {
   type        = "string"
   description = "Tag used to lookup Elastic IP to assign"

--- a/docker-openvpn-server/cluster/main.tf
+++ b/docker-openvpn-server/cluster/main.tf
@@ -26,7 +26,7 @@ data "template_file" "user_data" {
 
 ## Creates auto scaling cluster
 module "cluster" {
-  source = "github.com/unifio/terraform-aws-asg?ref=v0.3.5//group"
+  source = "github.com/unifio/terraform-aws-asg?ref=v0.3.6//group"
 
   # Resource tags
   stack_item_label    = "${var.stack_item_label}"
@@ -48,11 +48,12 @@ module "cluster" {
   associate_public_ip_address   = "${var.associate_public_ip_address}"
 
   # ASG parameters
-  enabled_metrics   = "${var.enabled_metrics}"
-  hc_check_type     = "${var.enable_lb == "true" ? "ELB" : "EC2"}"
-  instance_tags     = "${var.instance_tags}"
-  max_size          = 2
-  min_size          = 1
-  hc_grace_period   = "${var.hc_grace_period}"
-  target_group_arns = "${var.lb_target_group_arns}"
+  additional_asg_tags = "${var.additional_asg_tags}"
+  enabled_metrics     = "${var.enabled_metrics}"
+  hc_check_type       = "${var.enable_lb == "true" ? "ELB" : "EC2"}"
+  instance_tags       = "${var.instance_tags}"
+  max_size            = 2
+  min_size            = 1
+  hc_grace_period     = "${var.hc_grace_period}"
+  target_group_arns   = "${var.lb_target_group_arns}"
 }

--- a/docker-openvpn-server/cluster/variables.tf
+++ b/docker-openvpn-server/cluster/variables.tf
@@ -60,6 +60,12 @@ variable "instance_tags" {
   }
 }
 
+variable "additional_asg_tags" {
+  type        = "list"
+  description = "Additional tags to apply at the ASG level, if any"
+  default     = []
+}
+
 variable "enabled_metrics" {
   type = "list"
 


### PR DESCRIPTION
* Added aditional_asg_tags to support providing these to the openvpn asg cluster.
* Bumped version of terraform-aws-asg module to 0.3.6 that supports the additional_asg_tags.